### PR TITLE
Puppet agent config needs the puppet_server option

### DIFF
--- a/templates/puppetagent.conf.erb
+++ b/templates/puppetagent.conf.erb
@@ -27,6 +27,11 @@
     environment = <%= scope['::environment'] %>
 
 <% end -%>
+<% if @puppet_server -%>
+    # Puppet master host
+    server = <%= @puppet_server %>
+
+<% end %>
 <% if @report -%>
     # Send report (useful for the Puppet Dashboard)
     report = true


### PR DESCRIPTION
I ran into this problem when setting up a puppet master that doesn't use the traditional 'puppet' name. I think you forgot to include the puppet server option in the agent configuration file. Otherwise everything worked quite nicely.
