### PR TITLE
Toggle master/ca role

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -9,6 +9,7 @@ class puppet::agent (
   $cron_minute        = fqdn_rand(60),
   # puppet.conf options
   $rundir             = $::puppet::params::rundir,
+  $ssldir             = $::puppet::params::ssldir,
   $pluginsync         = 'true',
   $report             = false,
   $forcenoop          = false,

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -3,6 +3,7 @@ class puppet::master (
   $runtype        = 'service',
   $selinux        = $::selinux,
   $scontext       = 'httpd_passenger_helper_t',
+  $ca_server      = true,
   # puppet.conf options
   $certname       = undef,
   $dns_alt_names  = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@ class puppet::params {
     'Fedora', 'RedHat', 'CentOS': {
       $sysconfig = true
       $rundir = '/var/run/puppet'
+      $ssldir = '\$vardir/ssl'
     }
     'Gentoo', 'Archlinux': {
       $sysconfig = false

--- a/templates/httpd-puppet.conf.erb
+++ b/templates/httpd-puppet.conf.erb
@@ -14,11 +14,20 @@ PassengerStatThrottleRate 120
 
     SSLCertificateFile /var/lib/puppet/ssl/certs/<%= @https_certname %>.pem
     SSLCertificateKeyFile /var/lib/puppet/ssl/private_keys/<%= @https_certname %>.pem
+    <% if @ca_server -%>
     SSLCertificateChainFile /var/lib/puppet/ssl/ca/ca_crt.pem
     SSLCACertificateFile /var/lib/puppet/ssl/ca/ca_crt.pem
+    <%- else -%>
+    SSLCertificateChainFile /var/lib/puppet/ssl/certs/ca.pem
+    SSLCACertificateFile /var/lib/puppet/ssl/certs/ca.pem
+    <%- end -%>
     # If Apache complains about invalid signatures on the CRL, you can try disabling
     # CRL checking by commenting the next line, but this is not recommended.
+    <% if @ca_server -%>
     SSLCARevocationFile /var/lib/puppet/ssl/ca/ca_crl.pem
+    <%- else -%>
+    SSLCARevocationFile /var/lib/puppet/ssl/crl.pem
+    <%- end -%>
     SSLVerifyClient optional
     SSLVerifyDepth 1
     SSLOptions +StdEnvVars


### PR DESCRIPTION
Hello!
Please consider this MR.
Currently I'm using your module to setup my puppetmasters, but sometimes I want those masters to be only masters but not a PuppetCA.
This change toggles PuppetMaster/PuppetCA role.