### PR TITLE
Optionally configure environment in agent

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -1,24 +1,25 @@
 class puppet::agent (
-  $service            = true,
-  $sysconfig          = $::puppet::params::sysconfig,
-  $master             = $::puppet_puppetmaster,
+  $service               = true,
+  $sysconfig             = $::puppet::params::sysconfig,
+  $master                = $::puppet_puppetmaster,
   # Simple hourly cron job, only if the service is disabled
-  $cron_enable        = false,
-  $cron_silent        = false,
-  $cron_hour          = '*',
-  $cron_minute        = fqdn_rand(60),
+  $cron_enable           = false,
+  $cron_silent           = false,
+  $cron_hour             = '*',
+  $cron_minute           = fqdn_rand(60),
   # puppet.conf options
-  $rundir             = $::puppet::params::rundir,
-  $pluginsync         = 'true',
-  $report             = false,
-  $forcenoop          = false,
-  $main_extraopts     = {},
-  $agent_extraopts    = {},
+  $rundir                = $::puppet::params::rundir,
+  $pluginsync            = 'true',
+  $report                = false,
+  $forcenoop             = false,
+  $configure_environment = true,
+  $main_extraopts        = {},
+  $agent_extraopts       = {},
   # sysconfig / repuppet options
-  $puppet_server      = 'puppet',
-  $puppet_port        = '8140',
-  $puppet_log         = '/var/log/puppet/puppet.log',
-  $puppet_extra_opts  = '',
+  $puppet_server         = 'puppet',
+  $puppet_port           = '8140',
+  $puppet_log            = '/var/log/puppet/puppet.log',
+  $puppet_extra_opts     = '',
 ) inherits ::puppet::params {
 
   include '::puppet::common'

--- a/templates/puppetagent.conf.erb
+++ b/templates/puppetagent.conf.erb
@@ -23,7 +23,7 @@
 <% end -%>
 
 [agent]
-<% if scope['::environment'] != 'production' -%>
+<% if scope['::environment'] != 'production' && @configure_environment -%>
     environment = <%= scope['::environment'] %>
 
 <% end -%>


### PR DESCRIPTION
Setting configure_environment to false will leave the setting
environment out of their puppet.conf. This is useful when using
environments in the puppet lifecycle instead of node segregation.

The default setting of true works as before - setting environment when
the environment is not 'production'.